### PR TITLE
Add Google Analytics to website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -86,3 +86,9 @@ category_archive:
 tag_archive:
   type: liquid
   path: /tags/
+
+analytics:
+  provider: "google-gtag"
+  google:
+    tracking_id: "G-EHQ00GXXST"
+    anonymize_ip: false


### PR DESCRIPTION
Created a Google Analytics property in GA, then added its config to the website's _config.yml. Will need to ensure the Jekyll build process is set to 'production' in order to work.