### PR TITLE
Minor fixes

### DIFF
--- a/_pages/funds-community.md
+++ b/_pages/funds-community.md
@@ -23,10 +23,15 @@ To maximise the effectiveness of this opportunity, the fund will be administered
 
 The total value of this fund is £150k to be administered throughout the duration of the CHARTED project, with the maximum award per activity being £5k (event series will also be considered). The eligibility criteria and the review process are described below.
 
+**The fund is designed to support specific activities and directly associated costs only. Requests for equipment or human effort are not eligible.**
+Applicants should therefore gain approval from their institutions to cover the time spent on the activities for which they seek support.
+
 <details class="accordion">
 <summary>Who can apply</summary>
 
 This fund is aimed at UK-based researchers and dRTPs involved with research software, research data and research computing infrastructure, or supporting other dRTPs. Applicants can be based at UK universities or UK-based non-profit organisations. Note that it is possible to apply for funds to support non-UK based collaborators to come to the UK. Individuals who operate principally as freelance trainers, educators or community managers in this sector are also eligible to apply for Fund 2.
+<br>
+<br>
 This fund will cover 100% of the <a href="https://www.ukri.org/councils/epsrc/guidance-for-applicants/costs-you-can-apply-for/principles-of-full-economic-costing-fec/">Full Economic Costs (FEC)</a> of the proposed activity. of the proposed activity. 
 
 </details>
@@ -68,10 +73,10 @@ A <a href="https://digitalresearchinfrastructure.grantplatform.com/entry/manager
 Applications are being managed through the <a href="https://digitalresearchinfrastructure.grantplatform.com/">Good Grants Platform</a>. You will need to register on the platform and sign in to access and complete the online form to submit an application to fund 2. <a href="https://digitalresearchinfrastructure.grantplatform.com/">Apply via Good Grants</a>.
 <br>
 <br>
-The number of applications funded in each round will depend on the quality of the applications and the amount of funding requested.
+The number of applications funded in each round will depend on the quality of the applications and the amount of funds requested.
 <br>
 <br>
-If you have any questions about the application or review process please get in touch with us at: <a href="mailto:charted@drtp-skills.ac.uk">charted@drtp-skills.ac.uk</a> 
+If you have any questions about the application or review process please get in touch with us at: <a href="mailto:charted@drtp-skills.ac.uk">charted@drtp-skills.ac.uk</a>
 
 </details>
 

--- a/_pages/funds-community.md
+++ b/_pages/funds-community.md
@@ -23,7 +23,7 @@ To maximise the effectiveness of this opportunity, the fund will be administered
 
 The total value of this fund is £150k to be administered throughout the duration of the CHARTED project, with the maximum award per activity being £5k (event series will also be considered). The eligibility criteria and the review process are described below.
 
-**The fund is designed to support specific activities and directly associated costs only. Requests for equipment or human effort are not eligible.**
+**The fund is designed to support specific community activities by reimbursing costs such as room/venue hire and catering. Requests for funding to cover staff time or the purchase of equipment are not eligible.**
 Applicants should therefore gain approval from their institutions to cover the time spent on the activities for which they seek support.
 
 <details class="accordion">

--- a/_pages/funds-community.md
+++ b/_pages/funds-community.md
@@ -32,7 +32,7 @@ Applicants should therefore gain approval from their institutions to cover the t
 This fund is aimed at UK-based researchers and dRTPs involved with research software, research data and research computing infrastructure, or supporting other dRTPs. Applicants can be based at UK universities or UK-based non-profit organisations. Note that it is possible to apply for funds to support non-UK based collaborators to come to the UK. Individuals who operate principally as freelance trainers, educators or community managers in this sector are also eligible to apply for Fund 2.
 <br>
 <br>
-This fund will cover 100% of the <a href="https://www.ukri.org/councils/epsrc/guidance-for-applicants/costs-you-can-apply-for/principles-of-full-economic-costing-fec/">Full Economic Costs (FEC)</a> of the proposed activity. of the proposed activity. 
+This fund will cover 100% of the <a href="https://www.ukri.org/councils/epsrc/guidance-for-applicants/costs-you-can-apply-for/principles-of-full-economic-costing-fec/">Full Economic Costs (FEC)</a> of the proposed activity.
 
 </details>
 

--- a/_pages/funds-community.md
+++ b/_pages/funds-community.md
@@ -71,12 +71,6 @@ A <a href="https://digitalresearchinfrastructure.grantplatform.com/entry/manager
 <summary>How to apply</summary>
 
 Applications are being managed through the <a href="https://digitalresearchinfrastructure.grantplatform.com/">Good Grants Platform</a>. You will need to register on the platform and sign in to access and complete the online form to submit an application to fund 2. <a href="https://digitalresearchinfrastructure.grantplatform.com/">Apply via Good Grants</a>.
-<br>
-<br>
-The number of applications funded in each round will depend on the quality of the applications and the amount of funds requested.
-<br>
-<br>
-If you have any questions about the application or review process please get in touch with us at: <a href="mailto:charted@drtp-skills.ac.uk">charted@drtp-skills.ac.uk</a>
 
 </details>
 
@@ -87,15 +81,10 @@ Applications will be assessed using a light-touch review process to ensure timel
 <br>
 <br>
 Applications will be ranked according to the benefits to the individuals and their local community. Please see the previous section for details on what should be included in the applications.
-<br>
-<br>
-The number of applications funded in each round will depend on the quality of the applications and the amount of funds requested.
-<br>
-<br>
-If you have any questions about the application or review process please get in touch with us at: <a href="mailto:charted@drtp-skills.ac.uk">charted@drtp-skills.ac.uk</a>
 
 </details>
 
+The number of applications funded in each round will depend on the quality of the applications and the amount of funds requested.
 
-
+If you have any questions about the application or review process please get in touch with us at: <a href="mailto:charted@drtp-skills.ac.uk">charted@drtp-skills.ac.uk</a>
 

--- a/_pages/funds-community.md
+++ b/_pages/funds-community.md
@@ -24,7 +24,7 @@ To maximise the effectiveness of this opportunity, the fund will be administered
 The total value of this fund is £150k to be administered throughout the duration of the CHARTED project, with the maximum award per activity being £5k (event series will also be considered). The eligibility criteria and the review process are described below.
 
 **The fund is designed to support specific community activities by reimbursing costs such as room/venue hire and catering. Requests for funding to cover staff time or the purchase of equipment are not eligible.**
-Applicants should therefore gain approval from their institutions to cover the time spent on the activities for which they seek support.
+Applicants should therefore gain approval from their home institution to cover the time spent on the activities for which they seek support.
 
 <details class="accordion">
 <summary>Who can apply</summary>

--- a/_pages/funds-prof-dev.md
+++ b/_pages/funds-prof-dev.md
@@ -24,6 +24,9 @@ To maximise the effectiveness of this opportunity, the fund will be administered
 
 The total value of this fund is £150k to be administered throughout the duration of the CHARTED project, with the maximum award per individual being £5k. The eligibility criteria and the review process are described below. 
 
+**The fund is designed to support specific activities and directly associated costs only. Requests for equipment or human effort are not eligible.**
+Applicants should therefore gain approval from their institutions to cover the time spent on the activities for which they seek support.
+
 <details class="accordion">
 <summary>Who can apply</summary>
 
@@ -45,12 +48,7 @@ Applicants are expected to include the following in their applications:
 <li>Detailed breakdown for the expected costs and justification for the requested funds.</li>
 </ul>
 
-<strong>The fund is designed to support specific activities and directly associated costs only. Requests for equipment or human effort are not eligible.</strong>
-<br>
-<br>
-Applicants should therefore gain approval from their institutions to cover the time spent on the activities for which they seek support.
-<br>
-<br>
+
 By default this award will be administered following the reimbursement model, applicants will therefore be expected to keep good records of all expenses. Final reimbursement requests should be within 10% of the requested costs. If this model does not work for you, please indicate that clearly in your application. You must apply and be successful in your application before the activity you seek support for takes place.
 <br>
 <br>

--- a/_pages/funds-prof-dev.md
+++ b/_pages/funds-prof-dev.md
@@ -24,8 +24,8 @@ To maximise the effectiveness of this opportunity, the fund will be administered
 
 The total value of this fund is £150k to be administered throughout the duration of the CHARTED project, with the maximum award per individual being £5k. The eligibility criteria and the review process are described below. 
 
-**The fund is designed to support specific activities and directly associated costs only. Requests for equipment or human effort are not eligible.**
-Applicants should therefore gain approval from their institutions to cover the time spent on the activities for which they seek support.
+**The fund is designed to support specific professional development activities by reimbursing costs such as access to training courses or travel costs and registration fees for attending conferences or events that would support an individual's professional development. Requests for funding to cover staff time are not eligible.**
+Applicants should therefore gain approval from their home institution to cover the time spent on the activities for which they seek support.
 
 <details class="accordion">
 <summary>Who can apply</summary>

--- a/_pages/funds-prof-dev.md
+++ b/_pages/funds-prof-dev.md
@@ -51,7 +51,7 @@ Applicants are expected to include the following in their applications:
 Applicants should therefore gain approval from their institutions to cover the time spent on the activities for which they seek support.
 <br>
 <br>
-By default this award will be administered following the reimbursement model, applicants will therefore be expected to keep good records of all your expenses. Final reimbursement requests should be within 10% of the requested costs. If this model does not work for you, please indicate that clearly in your application. You must apply and be successful in your application before the activity you seek support for takes place.
+By default this award will be administered following the reimbursement model, applicants will therefore be expected to keep good records of all expenses. Final reimbursement requests should be within 10% of the requested costs. If this model does not work for you, please indicate that clearly in your application. You must apply and be successful in your application before the activity you seek support for takes place.
 <br>
 <br>
 The successful applicants commit to:

--- a/_pages/funds-prof-dev.md
+++ b/_pages/funds-prof-dev.md
@@ -49,7 +49,7 @@ Applicants are expected to include the following in their applications:
 </ul>
 
 
-By default this award will be administered following the reimbursement model, applicants will therefore be expected to keep good records of all expenses. Final reimbursement requests should be within 10% of the requested costs. If this model does not work for you, please indicate that clearly in your application. You must apply and be successful in your application before the activity you seek support for takes place.
+By default this award will be administered following the reimbursement model, applicants will therefore be expected to keep comprehensive records of all expenses. Final reimbursement requests should be within 10% of the requested costs. If this model does not work for you, please indicate that clearly in your application. You must apply and be successful in your application before incurring any costs in relation to the activity you are seeking support for.
 <br>
 <br>
 The successful applicants commit to:

--- a/_pages/funds.md
+++ b/_pages/funds.md
@@ -13,28 +13,28 @@ This will be used to support the community-driven activities and initiatives tha
 
 **Fund:**  £350k for small projects up to around £5k and a small number of bigger projects up to £100k.
 
-**Timeframe:**  Call expected to open in late 2025/ early 2026, to complete by early 2028.
+**Timeframe:**  Call expected to open in Summer 2026, to complete by early 2028.
 
 ### Fund 2:  Community Activities
 **Purpose:**   To support community-wide activities, mostly at national level.  These may include creation and support of RTP networks, mentoring programmes, events focussed on capturing career profiles, career development and engagement with other stakeholders eg in industry.
 
 **Fund:**   £150k with up to around £5k per event.
 
-**Timeframe:**   Call expected to open around October 2025, to complete by the end of 2028.
+**Timeframe:**   Call opened in April 2026, to complete by the end of 2028.
 
 ### Fund 3:  Tools and Frameworks
 **Purpose:**   To support development of new tools and frameworks to improve the navigability of the ecosystem.  Activities might include design, creation or testing of new tools for self-assessment, tools that improve navigation, new approaches to continuous professional development and creation of best practice resources.  Expressions of interest will be collected, and we may consider merging some projects.
 
 **Fund:**  £350k for small projects of up to around £5k, bigger projects up to £150k.
 
-**Timeframe:**   Call expected to open in late 2025/ early 2026, to complete by the end of 2028.
+**Timeframe:**   Call expected to open in Summer 2026, to complete by the end of 2028.
 
 ### Fund 4:  Professional Development
 **Purpose:**   To support professional development of individuals who may be early in their career, returning after a break or re-orienting themselves in their careers.  Activities may include attending conferences or events, fees for training courses or certificates and visits to other institutions for knowledge exchange.
 
 **Fund:**   £150k with up to around £5k per individual
 
-**Timeframe:**   Call expected to open around October 2025, to complete by the end of 2028.
+**Timeframe:**   Call opened in February 2026, to complete by the end of 2028.
 
 ### CHARTED flexible funds webinar
 On Tuesday 14th April 2026, the CHARTED project hosted a webinar to provide some background on the project and introduce the two funds accepting applications at the time of recording - Fund 2 (Community activities) and Fund 4 (Professional development). You can watch the recording of this webinar below which also provides details of how to apply to the CHARTED funds via the GoodGrants platform.


### PR DESCRIPTION
There are three commits in this PR:

- the first commit copied text from fund 4 into fund to clarify that staff costs aren't allowed
- the second commit updated the dates when funds 2 and 4 opened and when funds 1 and 3 are expected to open. there was also an error in fund 2 with a phrase being repeated, I just deleted that
- the third commit is more of a suggestion. i put the text re staff costs in the general description for fund 2, but it is within the 'what we are looking for' section in fund 4, which is less visible. some text in fund 2 was repeated (i.e. how many applications will be funded and our email address). I removed that from both sections and placed it at the bottom where it is more visible. It also felt more appropriate as it appears to be relevant for different info sections